### PR TITLE
Fix "-m" and "--message" option of "CLOSE" command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: go
 sudo: false
 go:

--- a/fmcsadmin.go
+++ b/fmcsadmin.go
@@ -239,10 +239,8 @@ func (c *cli) Run(args []string) int {
 						for i := 0; i < len(idList); i++ {
 							u.Path = path.Join(getAPIBasePath(baseURI), "databases", strconv.Itoa(idList[i]), "close")
 							exitStatus, _, err = sendRequest("PUT", u.String(), token, params{command: "close", message: message})
-							if exitStatus == 0 && err == nil && len(message) == 0 && len(connectedClients) == 0 {
-								// Don't output this message
-								//   1. when using "-m (--message)" option
-								//   2. when the clients connected to the specified databases are existing
+							if exitStatus == 0 && err == nil && len(connectedClients) == 0 {
+								// Don't output this message when the clients connected to the specified databases are existing
 								fmt.Fprintln(c.outStream, "File Closed: "+nameList[i])
 							}
 						}

--- a/fmcsadmin.go
+++ b/fmcsadmin.go
@@ -94,6 +94,7 @@ type runningInfo struct {
 }
 
 type params struct {
+	command              string
 	key                  string
 	message              string
 	gracetime            int
@@ -237,7 +238,7 @@ func (c *cli) Run(args []string) int {
 						connectedClients := getClients(u.String(), token, args, "")
 						for i := 0; i < len(idList); i++ {
 							u.Path = path.Join(getAPIBasePath(baseURI), "databases", strconv.Itoa(idList[i]), "close")
-							exitStatus, _, err = sendRequest("PUT", u.String(), token, params{message: message})
+							exitStatus, _, err = sendRequest("PUT", u.String(), token, params{command: "close", message: message})
 							if exitStatus == 0 && err == nil && len(message) == 0 && len(connectedClients) == 0 {
 								// Don't output this message
 								//   1. when using "-m (--message)" option
@@ -2245,7 +2246,7 @@ func stopDatabaseServer(u *url.URL, baseURI string, token string, message string
 	if len(idList) > 0 {
 		for i := 0; i < len(idList); i++ {
 			u.Path = path.Join(getAPIBasePath(baseURI), "databases", strconv.Itoa(idList[i]), "close")
-			exitStatus, _, err = sendRequest("PUT", u.String(), token, params{message: message})
+			exitStatus, _, err = sendRequest("PUT", u.String(), token, params{command: "close", message: message})
 		}
 	}
 
@@ -2310,15 +2311,15 @@ func sendRequest(method string, url string, token string, p params) (int, bool, 
 			p.key,
 		}
 		jsonStr, _ = json.Marshal(d)
+	} else if (params{}) != p && reflect.ValueOf(p.command).IsValid() == true && p.command == "close" {
+		d := messageInfo{
+			p.message,
+		}
+		jsonStr, _ = json.Marshal(d)
 	} else if (params{}) != p && reflect.ValueOf(p.gracetime).IsValid() == true && p.gracetime >= 0 {
 		d := disconnectMessageInfo{
 			p.message,
 			p.gracetime,
-		}
-		jsonStr, _ = json.Marshal(d)
-	} else if (params{}) != p && reflect.ValueOf(p.message).IsValid() == true && len(p.message) > 0 {
-		d := messageInfo{
-			p.message,
 		}
 		jsonStr, _ = json.Marshal(d)
 	} else if (params{}) != p && reflect.ValueOf(p.characterencoding).IsValid() == true && len(p.characterencoding) > 0 {

--- a/fmcsadmin_test.go
+++ b/fmcsadmin_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -503,13 +505,21 @@ func TestRunCloseCommand1(t *testing.T) {
 	if running == false {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintln(w, "{\"result\": 0, \"token\": \"ACCESSTOKEN\", \"totalDBCount\": 1, \"files\": {\"files\": [{\"status\": \"NORMAL\", \"filename\": \"TestDB.fmp12\"}]}}")
-			if r.URL.Path == "/fmi/admin/api/v1/databases/0/close" {
+			if r.URL.Path == "/admin/api/v1/databases/0/close" || r.URL.Path == "/fmi/admin/api/v1/databases/0/close" {
 				request, _ := ioutil.ReadAll(r.Body)
 				assert.Equal(t, "{\"message\":\"MESSAGE\"}", string([]byte(request)))
 			}
 		})
 
-		l, _ := net.Listen("tcp", "127.0.0.1:16001")
+		address := "127.0.0.1:16001"
+		ci := os.Getenv("TRAVIS")
+		if ci == "true" {
+			address = "127.0.0.1:8080"
+		}
+		l, err := net.Listen("tcp", address)
+		if err != nil {
+			log.Fatal(err)
+		}
 		ts := httptest.Server{
 			Listener: l,
 			Config:   &http.Server{Handler: handler},
@@ -518,8 +528,6 @@ func TestRunCloseCommand1(t *testing.T) {
 		defer ts.Close()
 	}
 
-	/*
-	[WIP]
 	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
 	cli := &cli{outStream: outStream, errStream: errStream}
 	args := strings.Split("fmcsadmin close TestDB -y -u USERNAME -p PASSWORD -m MESSAGE", " ")
@@ -527,7 +535,6 @@ func TestRunCloseCommand1(t *testing.T) {
 	assert.Equal(t, 0, status)
 	expected := "TestDB.fmp12"
 	assert.Contains(t, outStream.String(), expected)
-	*/
 }
 
 func TestRunStatusCommand1(t *testing.T) {

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -6,6 +6,7 @@ Version: 0.9.3 (in development)
 - Add an error message for the FileMaker error code 214.
 - Built with Go 1.11.
 - [BUG FIX] Fix "-m" and "--message" option of "CLOSE" command. The affected version is 0.9.2 only.
+- [BUG FIX] Output "File Closed:" when using "-m" or "--message" option of "CLOSE" command and there is no client connected to the specified databases.
 
 Version: 0.9.2 (beta)
 Date: July 6, 2018

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -5,6 +5,7 @@ This software is distributed under the Apache License, Version 2.0, see LICENSE.
 Version: 0.9.3 (in development)
 - Add an error message for the FileMaker error code 214.
 - Built with Go 1.11.
+- [BUG FIX] Fix "-m" and "--message" option of "CLOSE" command. The affected version is 0.9.2 only.
 
 Version: 0.9.2 (beta)
 Date: July 6, 2018


### PR DESCRIPTION
The affected version is 0.9.2 only.